### PR TITLE
Bug PSP-2409

### DIFF
--- a/src/daterangepicker/directives/date-range-picker.directive.ts
+++ b/src/daterangepicker/directives/date-range-picker.directive.ts
@@ -436,7 +436,7 @@ export class DateRangePickerDirective implements OnInit, OnChanges, DoCheck {
 
 		if (
 			!this.elementRef.nativeElement.contains(event.target) &&
-			(event.target as HTMLSpanElement)?.className?.indexOf('mat-option') === -1
+			(event.target as Element)?.getAttribute('class')?.indexOf('mat-option') === -1
 		) {
 			this.hide();
 		}


### PR DESCRIPTION
PSP-2460
- use the getAttribute method of Element rather than className because className can be an SVGAnimatedString which does not have indexOf method on it.

https://accesso.atlassian.net/browse/PSP-2409